### PR TITLE
Fix for the Okta Client ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 
 apply from: 'plugin-common.gradle'
 
-project.ext.pluginVersion = '1.0.0'
+project.ext.pluginVersion = '1.1.0'
 project.ext.fullVersion = project.distVersion ? "${project.pluginVersion}-${project.distVersion}" : project.pluginVersion
 
 version = project.fullVersion
@@ -30,8 +30,8 @@ project.ext.pluginDesc = [
         goCdVersion: '17.5.0',
         name       : 'Okta oauth authorization plugin',
         description: 'Okta oauth authorization plugin for GoCD',
-        vendorName : 'GoCD Contributors',
-        vendorUrl  : 'https://github.com/gocd-contrib/okta-oauth-authorization-plugin'
+        vendorName : 'szamfirov',
+        vendorUrl  : 'https://github.com/szamfirov/okta-oauth-authorization-plugin'
 ]
 
 repositories {
@@ -44,7 +44,7 @@ dependencies {
     compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.1'
 
-    testCompile group: 'cd.go.plugin', name: 'go-plugin-api', version: '17.4.0'
+    testCompile group: 'cd.go.plugin', name: 'go-plugin-api', version: '17.5.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.2.28'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/src/main/java/cd/go/authorization/okta/OktaApiClient.java
+++ b/src/main/java/cd/go/authorization/okta/OktaApiClient.java
@@ -18,7 +18,6 @@ package cd.go.authorization.okta;
 
 import cd.go.authorization.okta.models.OktaConfiguration;
 import cd.go.authorization.okta.models.TokenInfo;
-import cd.go.authorization.okta.utils.Util;
 import okhttp3.*;
 
 import java.io.IOException;
@@ -27,6 +26,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static cd.go.authorization.okta.OktaPlugin.LOG;
+import static cd.go.authorization.okta.utils.Util.isBlank;
 import static cd.go.authorization.okta.utils.Util.isNotBlank;
 import static java.text.MessageFormat.format;
 
@@ -72,7 +72,7 @@ public class OktaApiClient {
 
     public TokenInfo fetchAccessToken(Map<String, String> params) throws Exception {
         final String code = params.get("code");
-        if (Util.isBlank(code)) {
+        if (isBlank(code)) {
             throw new RuntimeException("[OktaApiClient] Authorization code must not be null.");
         }
 

--- a/src/main/java/cd/go/authorization/okta/models/OktaConfiguration.java
+++ b/src/main/java/cd/go/authorization/okta/models/OktaConfiguration.java
@@ -37,7 +37,7 @@ public class OktaConfiguration implements Validatable {
 
     @Expose
     @SerializedName("ClientId")
-    @ProfileField(key = "ClientId", required = true, secure = true)
+    @ProfileField(key = "ClientId", required = true, secure = false)
     private String clientId;
 
     @Expose

--- a/src/main/resources/auth-config.template.html
+++ b/src/main/resources/auth-config.template.html
@@ -105,7 +105,7 @@
               </span>
             </div>
         </label>
-        <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientId].$error.server}" type="password" ng-model="ClientId" ng-required="true"/>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientId].$error.server}" type="text" ng-model="ClientId" ng-required="true"/>
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientId].$error.server}" ng-show="GOINPUTNAME[ClientId].$error.server">{{GOINPUTNAME[ClientId].$error.server}}</span>
     </div>
 

--- a/src/test/java/cd/go/authorization/okta/executors/GetAuthConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/okta/executors/GetAuthConfigMetadataRequestExecutorTest.java
@@ -55,7 +55,7 @@ public class GetAuthConfigMetadataRequestExecutorTest {
                 "    \"key\": \"ClientId\",\n" +
                 "    \"metadata\": {\n" +
                 "      \"required\": true,\n" +
-                "      \"secure\": true\n" +
+                "      \"secure\": false\n" +
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +


### PR DESCRIPTION
The client ID was set to be a secure variable leading to its value being
encrypted. This caused issues with the authentication and refresh token
redirects (the client ID is passed in those).

Fixes #2, fixes #3, fixes #5