### PR TITLE
Handle version 2.0 API as required by GoCD 23.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ out/
 !gradle-wrapper.jar
 
 classes/
+
+# osx junk
+.DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'java'
 
 apply from: 'plugin-common.gradle'
 
-project.ext.pluginVersion = '1.1.0'
+project.ext.pluginVersion = '1.2.0'
 project.ext.fullVersion = project.distVersion ? "${project.pluginVersion}-${project.distVersion}" : project.pluginVersion
 
 version = project.fullVersion
@@ -27,7 +27,7 @@ group = 'cd.go'
 project.ext.pluginDesc = [
         id         : 'cd.go.authorization.okta',
         version    : project.fullVersion,
-        goCdVersion: '17.5.0',
+        goCdVersion: '19.2.0',
         name       : 'Okta oauth authorization plugin',
         description: 'Okta oauth authorization plugin for GoCD',
         vendorName : 'szamfirov',
@@ -40,11 +40,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '17.5.0'
-    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.1'
+    compileOnly group: 'cd.go.plugin', name: 'go-plugin-api', version: '23.3.0'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.10.1'
     compile group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.1'
 
-    testCompile group: 'cd.go.plugin', name: 'go-plugin-api', version: '17.5.0'
+    testCompile group: 'cd.go.plugin', name: 'go-plugin-api', version: '23.3.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.2.28'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'

--- a/src/main/java/cd/go/authorization/okta/Constants.java
+++ b/src/main/java/cd/go/authorization/okta/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
     String EXTENSION_TYPE = "authorization";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "1.0";
+    String API_VERSION = "2.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));


### PR DESCRIPTION
Using the [authorization-skeleton-plugin](https://github.com/gocd-contrib/authorization-skeleton-plugin/commit/86c09a8ff52496781f5f23ff9dc501598ccb31d8) as the basis for updates.